### PR TITLE
Document transitiontime and on/off limitations

### DIFF
--- a/docs/endpoints/groups/index.md
+++ b/docs/endpoints/groups/index.md
@@ -472,7 +472,7 @@ Sets the state of a group.
     <tr>
       <td>transitiontime</td>
       <td>Number</td>
-      <td>Transition time in 1/10 seconds between two states.</td>
+      <td>Transition time in 1/10 seconds between two states. Note that not all states support a transition time. For example, a transition time when setting <pre>on</pre> will be ignored as the Zigbee On and Off commands do not support transition times. In general, light attributes that support a range of values support transition times, while boolean values do not.</td>
       <td>optional</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Following up from https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4548

If what I've written is correct, I will copy it into the `transitiontime` docs for lights and scenes.