### PR TITLE
Add .devcontainer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Thumbs.db
 .rvmrc
 
 venv/
+
+.devcontainer


### PR DESCRIPTION
Like in the deconz-rest-plugin repo add the .devcontainer folder to be ignored by git