### PR TITLE
Update configuration endpoint documentation

### DIFF
--- a/docs/endpoints/configuration/index.md
+++ b/docs/endpoints/configuration/index.md
@@ -176,7 +176,7 @@ ETag: "203941fel3ds8ad61903224"
         <tr>
             <td>gateway</td>
             <td>String</td>
-            <td>IPv4 address of the gateway.</td>
+            <td>IPv4 network gateway of the gateway.</td>
         </tr>
         <tr>
             <td>ipaddress</td>
@@ -249,7 +249,7 @@ ETag: "203941fel3ds8ad61903224"
             <td>Is true when the deCONZ is connected with the firmware and the Zigbee network is up.</td>
         </tr>
         <tr>
-            <td>softwareupdate</td>
+            <td>swupdate2</td>
             <td>Object</td>
             <td>Contains information related to software updates.</td>
         </tr>
@@ -862,7 +862,7 @@ HTTP/1.1 200 OK
 
 ## Reset password<a name="resetpw">&nbsp;</a>
 
-    DELETE /api/<apikey>/config/password
+    DELETE /api/config/password
 
 Resets the username and password to default username = “delight” and password = "delight”. The request can only succeed within 10 minutes after gateway start.
 


### PR DESCRIPTION
This pull request updates the documentation for the configuration endpoint. Specifically, it changes the description of the "gateway" field to clarify that it refers to the IPv4 network gateway of the gateway.
It also updates the "softwareupdate" field to "swupdate2" to align with the actual object name.
Additionally, it corrects the endpoint URL for resetting the password.