### PR TITLE
[Bundle] devices subdevices.endpoint attribute

### DIFF
--- a/docs/endpoints/devices/index.md
+++ b/docs/endpoints/devices/index.md
@@ -10,7 +10,7 @@ The Devices endpoint can be used to obtain more details on a device and its capa
 
     GET /api/<apikey>/devices
 
-Returns a list of all devices. If there are no devices in the system, an empty object {} is returned.
+Returns a list of all devices. If there are no devices in the system, an empty array [] is returned.
 
 ### Parameters
 
@@ -68,6 +68,7 @@ HTTP/1.1 200 OK
   "productid": "TRADFRI remote control E1810",
   "subdevices": [
     {
+      "endpoint": "/sensors/1",
       "config": {
         "alert": {
           "lastupdated": "2022-09-24T22:57:55Z",


### PR DESCRIPTION
This PR is a draft to discuss about changes to do for the DDF bundles.

To be able to fully use the /devices endpoint to do stuff we need a way to send requests that do something.
Until (if there is plan for it) the api have endpoints to update config, name, ...

It's would be a nice workaround to map the data returned by the `/devices/<device_mac_address>` endpoint.

So I suggest to add to the API inside the `subdevices` array a new `endpoint` property. The value will be with the format `/[sensors/lights]/[subdeviceID]` ex : `/sensors/1`

This is to solve the issue where from the data you get with the endpoint you have no way to find the device except by reading a full state and search for the subdevice.