### PR TITLE
[Bundle] Add device link endpoint

### DIFF
--- a/docs/endpoints/ddf/index.md
+++ b/docs/endpoints/ddf/index.md
@@ -54,7 +54,7 @@ The following tasks need to be clarified:
 
 - **Initial behaviour** when a device is joined it should automatically be assigned to a suiteable bundle, with the newest version, ideally a bundle that is signed with a "stable" signature.
 - **Manual update** Once a device is pinned to a bundle, updating to a new DDF bundle version needs to be done explicitly.
-  Like `PUT /api/<apikey>/devices/<uniqueid>/usebundle/<sha256>`, where the bundle with SHA-256 hash itself was [Uploaded](#uploadddfbundle) before.
+  Like `PUT /api/<apikey>/devices/<device_mac_address>/ddf`, where the bundle itself was [Uploaded](#uploadddfbundle) before.
 - **Auto updates** could be made an option, like auto update stable signed bundles. Each deCONZ release does contain the latest official DDF bundles. In future these can also be updated by loading fresh ones from the DDF store which doesn't depend on a deCONZ release.
 
 ------------------------------------------------------

--- a/docs/endpoints/devices/index.md
+++ b/docs/endpoints/devices/index.md
@@ -118,6 +118,7 @@ HTTP/1.1 200 OK
 
 [404 Not Found](../../misc/errors#404)
 
+
 ------------------------------------------------------
 
 ## Get Device DDF<a name="getdeviceddf">&nbsp;</a>
@@ -489,6 +490,86 @@ HTTP/1.1 200 OK
     The device returns the full DDF for the device.
 
 ### Possible errors
+
+[403 Forbidden](../../misc/errors#403)
+
+[404 Not Found](../../misc/errors#404)
+
+------------------------------------------------------
+
+## Set Device DDF<a name="setddf">&nbsp;</a>
+
+    PUT /api/<apikey>/devices/<device_mac_address>/ddf
+
+Set the mode to select DDF bundle for the device 
+
+<table class="table table-bordered">
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th><th>Required</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>mode</td>
+      <td>String</td>
+      <td>"auto" - "manual"</td>
+      <td>required</td>
+    </tr>
+    <tr>
+      <td>hash</td>
+      <td>String</td>
+      <td>"bundle_hash"</td>
+      <td>required if mode is manual</td>
+    </tr>
+  </tbody>
+</table>
+
+By default the device will use the DDF bundle with the latest modified date and compatible with the current deCONZ version. Only DDF bundle with the stable signature will be used in the "auto" mode.
+
+If you want to use a specific DDF bundle, you can set the mode to "manual" and provide the hash of the DDF bundle.
+
+#### Response fields
+
+<pre class="headers">
+<code class="no-highlight">
+HTTP/1.1 200 OK
+</code>
+</pre>
+<pre class="highlight">
+<code>
+[ { "success": { "mode": "auto" } } ]
+</code>
+</pre>
+<pre class="highlight">
+<code>
+[ { "success": { "mode": "manual", "bundle" : "bundle_hash" } } ]
+</code>
+</pre>
+
+### Possible errors
+
+<pre class="highlight">
+<code>
+{
+    "error": {
+        "type": 7,
+        "address": "devices/id",
+        "description": "Device not found"
+    }
+}
+</code>
+</pre>
+
+<pre class="highlight">
+<code>
+{
+    "error": {
+        "type": 7,
+        "address": "bundle/hash",
+        "description": "DDF Bundle not found"
+    }
+}
+</code>
+</pre>
 
 [403 Forbidden](../../misc/errors#403)
 


### PR DESCRIPTION
This PR is a draft to discuss about changes to do for the DDF bundles.

This pull request adds a new endpoint for linking device bundles. It allows devices to be assigned to a suitable bundle, with the newest version. This is the default beavior and will use any new version of a bundle shiped with the release.

The endpoint also supports manual updates to a new DDF bundle version. You can set the specific bundle to use for a device.

By default what is the list of the bundle that will be shiped with the deconz release ? Only the most used ? All ? None ?

If the user pair a device where  you currently don't have the a bundle for it what do we do ? Prompt the user about the missing configuration and redirect them to the store ?
Try to auto download a stable bundle for it if there is one avaliable ?