### PR TITLE
Update file extension for DDF bundle in documentation

### DIFF
--- a/docs/endpoints/ddf/index.md
+++ b/docs/endpoints/ddf/index.md
@@ -234,7 +234,7 @@ None
 
 ### Response
 
-The full DDF bundle as *&lt;sha25-hash&gt;.ddf* file.
+The full DDF bundle as *&lt;sha25-hash&gt;.ddb* file.
 
 ### Possible errors
 


### PR DESCRIPTION
The file extension for the DDF bundle in the documentation has been updated from ".ddf" to ".ddb". This ensures that the correct file extension is used when referring to the DDF bundle.